### PR TITLE
QDFVS-26 removing redundant event

### DIFF
--- a/franchises/dfv/dist/js/main.js
+++ b/franchises/dfv/dist/js/main.js
@@ -360,9 +360,10 @@ __webpack_require__.r(__webpack_exports__);
         'placeholder': placeholder,
         'width': '100%'
       });
-      select_inputs.on('select2:open', function (e) {
-        $('.select2-search input').prop('focus', false);
-      });
+      /*select_inputs.on('select2:open', function(e) {
+          $('.select2-search input').prop('focus',false);
+      });*/
+
       /*select_inputs.on('change', function(event) {
           var target_input = $(event.target);
           qg_dfv.fn.checkForConditionalEvents(target_input);

--- a/franchises/dfv/src/modules/data-filter/js/global.js
+++ b/franchises/dfv/src/modules/data-filter/js/global.js
@@ -117,9 +117,9 @@ import { isDevelopment, sendXHR, findLink, generateLoader } from "../../../lib/u
                 'width': '100%'
             });
 
-            select_inputs.on('select2:open', function(e) {
+            /*select_inputs.on('select2:open', function(e) {
                 $('.select2-search input').prop('focus',false);
-            });
+            });*/
 
             /*select_inputs.on('change', function(event) {
                 var target_input = $(event.target);


### PR DESCRIPTION
I had a really strange recursion error that was only occurring on QLD Online and not in localhost. 

Commenting out an event that's no longer valid seems to have stabilised the QLD Online version.