### PR TITLE
DC-12121 Wrapped img tag inside primary parent to avoid affecting log…

### DIFF
--- a/open-data/src/styles/global.scss
+++ b/open-data/src/styles/global.scss
@@ -82,10 +82,6 @@ body {
     }
 }
 
-img {
-    max-width: 100%;
-}
-
  main.main {
     background: $white;
 }
@@ -134,6 +130,10 @@ a {
 
 .primary {
     padding: 0;
+    
+    img {
+        max-width: 100%;
+    }
 }
 
 #asides .button:visited, 


### PR DESCRIPTION
img css attributes (max-width) flows onto the header, causing issues in legacy IE.
This has been corrected by wrapping .img underneath the primary parent container (scss).

* Pull request from feature to master (open-data/dev branch is 369 commits behind) 