### PR TITLE
[QOLSVC-6119] add support for alternative class on collapsing elements

### DIFF
--- a/open-data/src/modules/navbar-bs5/css/global.scss
+++ b/open-data/src/modules/navbar-bs5/css/global.scss
@@ -4,12 +4,12 @@
 }
 
 @media screen and (max-width: $tablet){
-    .navbar-collapse.collapse {    
+    .navbar-collapse.collapse {
         //Menu Collapsed state
-        &:not(.in) { display: none !important; }
-    
+        &:not(.in, .show) { display: none !important; }
+
         //Menu Open state
-        &.in { display: block !important; }
+        &.in, &.show { display: block !important; }
     }
 }
 

--- a/open-data/src/modules/navigation/css/bs5-navbar-support.scss
+++ b/open-data/src/modules/navigation/css/bs5-navbar-support.scss
@@ -1,9 +1,9 @@
-.navbar-collapse.collapse {    
+.navbar-collapse.collapse {
     //Menu Collapsed state
-    &:not(.in) { display: none !important; }
-    
+    &:not(.in, .show) { display: none !important; }
+
     //Menu Open state
-    &.in { display: block !important; }
+    &.in, &.show { display: block !important; }
 }
 
 .header-image.pull-left {

--- a/open-data/static/js/main.js
+++ b/open-data/static/js/main.js
@@ -374,7 +374,7 @@ function _typeof(obj) { if (typeof Symbol === "function" && typeof Symbol.iterat
       show: function show() {
         var t, n, r, i;
         if (this.transitioning || this.$element.hasClass("in")) return;
-        t = this.dimension(), n = e.camelCase(["scroll", t].join("-")), r = this.$parent && this.$parent.find("> .accordion-group > .in");
+        t = this.dimension(), n = e.camelCase(["scroll", t].join("-")), r = this.$parent && this.$parent.find("> .accordion-group > .in, > .accordion-group > .show,");
 
         if (r && r.length) {
           i = r.data("collapse");


### PR DESCRIPTION
- Stylesheets previously expected the 'in' class but some versions of Bootstrap use 'show'