### PR TITLE
[QOLDEV-954] reduce column padding to better accommodate datatables previews

### DIFF
--- a/open-data/src/styles/global.scss
+++ b/open-data/src/styles/global.scss
@@ -130,17 +130,17 @@ a {
 
 .primary {
     padding: 0;
-    
+
     img {
         max-width: 100%;
     }
 }
 
-#asides .button:visited, 
-.button, .button:active, 
-.button:focus, 
-.button:hover, 
-.button:link, 
+#asides .button:visited,
+.button, .button:active,
+.button:focus,
+.button:hover,
+.button:link,
 .button:visited,
 .button {
 
@@ -196,7 +196,7 @@ a {
 
 @media screen and (min-width: $tablet){
     .primary {
-        padding-left: pxToRem(45);
+        padding-left: pxToRem(15);
     }
 }
 


### PR DESCRIPTION
- If the column is too narrow then DataTables thinks we're on mobile, which ends up messy